### PR TITLE
Very dirty fix for nanosvg.h to C#

### DIFF
--- a/src/Hebron/Hebron.csproj
+++ b/src/Hebron/Hebron.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClangSharp" Version="20.1.2.1" />
+    <PackageReference Include="ClangSharp" Version="21.1.8.3" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.14.0" />
   </ItemGroup>
 

--- a/src/Hebron/Roslyn/RoslynCodeConverter.Functions.cs
+++ b/src/Hebron/Roslyn/RoslynCodeConverter.Functions.cs
@@ -239,7 +239,7 @@ namespace Hebron.Roslyn
 				}
 			}
 
-			if (typeInfo.IsPointer && right.Deparentize() == "0")
+			if (typeInfo.IsPointer && (right.Deparentize() == "0" || string.IsNullOrEmpty(right.Deparentize())))
 			{
 				right = "null";
 			}
@@ -505,7 +505,7 @@ namespace Hebron.Roslyn
 						}
 
 						if (a.IsPointer && (type == CXBinaryOperatorKind.CXBinaryOperator_Assign || type.IsBooleanOperator()) &&
-							(b.Expression.Deparentize() == "0"))
+							(b.Expression.Deparentize() == "0" || string.IsNullOrEmpty(b.Expression.Deparentize())))
 						{
 							b.Expression = "null";
 						}
@@ -561,7 +561,7 @@ namespace Hebron.Roslyn
 							{
 								argExpr.Expression = argExpr.Expression.ApplyCast(argExpr.CsType);
 							}
-							else if (argExpr.Expression.Deparentize() == "0")
+							else if (argExpr.Expression.Deparentize() == "0" || string.IsNullOrEmpty(argExpr.Expression.Deparentize()))
 							{
 								argExpr.Expression = "null";
 							}
@@ -598,7 +598,7 @@ namespace Hebron.Roslyn
 							}
 						}
 
-						if (tt.IsPointer && ret.Deparentize() == "0")
+						if (tt.IsPointer && (ret.Deparentize() == "0" || string.IsNullOrEmpty(ret.Deparentize())))
 						{
 							ret = "null";
 						}
@@ -961,9 +961,9 @@ namespace Hebron.Roslyn
 						var tt = info.ToTypeInfo();
 						var csType = ToRoslynString(tt);
 
-						if (expr == "0" && tt.IsPointer)
+						if ((expr == "0" || string.IsNullOrEmpty(expr)) && tt.IsPointer)
 						{
-							// null
+							expr = "null";
 						} else if (csType != child.CsType)
 						{
 							// cast
@@ -986,7 +986,8 @@ namespace Hebron.Roslyn
 						var expr = ProcessChildByIndex(info, size - 1);
 
 						var typeInfo = info.ToTypeInfo();
-						if (typeInfo.IsPointer && expr.Expression.Deparentize() == "0")
+						var depExpr = expr.Expression.Deparentize();
+						if (typeInfo.IsPointer && (depExpr == "0" || string.IsNullOrEmpty(depExpr)))
 						{
 							expr.Expression = "null";
 						}

--- a/src/Hebron/Roslyn/RoslynUtility.cs
+++ b/src/Hebron/Roslyn/RoslynUtility.cs
@@ -29,7 +29,7 @@ namespace Hebron.Roslyn
 
 		private static readonly HashSet<string> _specialWords = new HashSet<string>(new[]
 		{
-			"out", "in", "base", "null", "string", "lock", "object", "class", "event"
+			"out", "in", "base", "null", "string", "lock", "object", "class", "event", "ref"
 		});
 
 		public static string FixSpecialWords(this string name)

--- a/src/Hebron/Utility.cs
+++ b/src/Hebron/Utility.cs
@@ -523,22 +523,33 @@ namespace Hebron
 				return spelling;
 			}
 
-			// clang_getCursorExtent is unreliable for tokens that originate
-			// from a macro body (not macro arguments) — it can return an
-			// extent whose end is EOF, spanning thousands of tokens.
-			// Instead, use clang_getToken to get the precise token at the
-			// cursor's source location without depending on the extent.
-			var location = clang.getCursorLocation(cursor);
+			// Try clang_getToken for a precise token at the cursor location.
+			var loc = clang.getCursorLocation(cursor);
 
 			unsafe
 			{
-				var token = clang.getToken(cursor.TranslationUnit, location);
+				var token = clang.getToken(cursor.TranslationUnit, loc);
 				if (token != null)
 				{
 					var result = clang.getTokenSpelling(cursor.TranslationUnit, *token).ToString();
 					clang.disposeTokens(cursor.TranslationUnit, token, 1);
-					return result;
+					if (!string.IsNullOrEmpty(result))
+					{
+						return result;
+					}
 				}
+			}
+
+			// clang_getCursorExtent is unreliable for tokens originating
+			// from a macro body — it can return an extent whose end is at
+			// EOF. Instead, construct a minimal zero-width range around the
+			// cursor's exact location and tokenize only that.
+			var minimalRange = CXSourceRange.Create(loc, loc);
+			var tokens = cursor.TranslationUnit.Tokenize(minimalRange);
+
+			if (tokens.Length > 0)
+			{
+				return tokens[0].GetSpelling(cursor.TranslationUnit).ToString();
 			}
 
 			return string.Empty;

--- a/src/Hebron/Utility.cs
+++ b/src/Hebron/Utility.cs
@@ -515,14 +515,33 @@ namespace Hebron
 
 		public static string GetTokenLiteral(this CXCursor cursor)
 		{
-			var tokens = cursor.TranslationUnit.Tokenize(cursor.SourceRange);
+			// Try cursor spelling first — works for most cases and is immune
+			// to clang returning an incorrect cursor extent.
+			var spelling = cursor.Spelling.ToString();
+			if (!string.IsNullOrEmpty(spelling))
+			{
+				return spelling;
+			}
 
-			Debug.Assert(tokens.Length == 1);
-			Debug.Assert(tokens[0].Kind == CXTokenKind.CXToken_Literal);
+			// clang_getCursorExtent is unreliable for tokens that originate
+			// from a macro body (not macro arguments) — it can return an
+			// extent whose end is EOF, spanning thousands of tokens.
+			// Instead, use clang_getToken to get the precise token at the
+			// cursor's source location without depending on the extent.
+			var location = clang.getCursorLocation(cursor);
 
-			var spelling = tokens[0].GetSpelling(cursor.TranslationUnit).ToString();
-			spelling = spelling.Trim('\\', '\r', '\n');
-			return spelling;
+			unsafe
+			{
+				var token = clang.getToken(cursor.TranslationUnit, location);
+				if (token != null)
+				{
+					var result = clang.getTokenSpelling(cursor.TranslationUnit, *token).ToString();
+					clang.disposeTokens(cursor.TranslationUnit, token, 1);
+					return result;
+				}
+			}
+
+			return string.Empty;
 		}
 
 		public unsafe static string[] Tokenize(this CXCursor cursor)


### PR DESCRIPTION
Very vibe-coded, use at your own risk. With this fix, NanoSVG almost compiles (the `nsvg__colors` initializer is invalid C#). Without it, it dies because the tokens.Length == 1 fails assertion (there's 7800 tokens in the macro expansion for NSVG_RGB for some reason)